### PR TITLE
ClassNLLCriterion - add support for one dimensional input

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,8 @@ set(src init.cpp utils.cpp
 set(luasrc init.lua MSECriterion.lua Pointwise.lua Threshold.lua LookupTable.lua
   LogSoftMax.lua ClassNLLCriterion.lua StatefulTimer.lua THCLNN.lua
   Narrow.lua CMulTable.lua test.lua test/testSpatialMaxPooling.lua test/testSpatialConvolutionMM.lua
-  test/testLookupTable.lua
-  test/testMSECriterion.lua test/testSoftMax.lua test/testLogSoftMax.lua test/testSpatialAveragePooling.lua)
+  test/testLookupTable.lua test/testMSECriterion.lua
+  test/testClassNLLCriterion.lua test/testSoftMax.lua test/testLogSoftMax.lua test/testSpatialAveragePooling.lua)
 ADD_TORCH_PACKAGE(clnn "${src}" "${luasrc}" )
 
 if(DEV_RUN_COG)

--- a/ClassNLLCriterion.lua
+++ b/ClassNLLCriterion.lua
@@ -16,23 +16,26 @@ function nn.ClassNLLCriterion:updateOutput(input, target)
    if torch.type(input) ~= 'torch.ClTensor' then
       return self:baseUpdateOutput(input, target)
    end
+
    if self.weights then
       error('weights not supported (yet!) in clnn.ClassNLLCriterion.  Please an issue on github, to request this functionality')
    end
+
    if input:dim() == 1 then
-      self.output = -input[target]
-      return self.output
+      assert(target:dim() == 1, 'target should be 1-d tensor')
+      assert(target:size(1) == 1, 'for non-batched input, target should be length 1')
+      self.output = -input[target[1]]
+   elseif input:dim() == 2 then
+     local num_samples = input:size(1)
+     local num_categories = input:size(2)
+     if self.buffer == nil then
+        self.buffer = input:clone():resize(num_samples,1)
+     end
+     self.buffer:gather(input, 2, target:unfold(1,1,1))
+     self.output = - self.buffer:sum() / num_samples
+   else
+      error('Input to clnn.ClassNLLCriterion should be 1-d or 2-d tensor')
    end
-   if input:dim() ~= 2 then
-      error('Input to clnn.ClassNLLCriterion should be 2-d tensor')
-   end
-   local num_samples = input:size(1)
-   local num_categories = input:size(2)
-   if self.buffer == nil then
-      self.buffer = input:clone():resize(num_samples,1)
-   end
-   self.buffer:gather(input, 2, target:unfold(1,1,1))
-   self.output = - self.buffer:sum() / num_samples
    return self.output
 end
 
@@ -46,7 +49,7 @@ function nn.ClassNLLCriterion:updateGradInput(input, target)
    self.gradInput:zero()
 
    if input:dim() == 1 then
-      self.gradInput[target] = -1
+      self.gradInput[target[1]] = -1
    else
       local z = -1
       if self.sizeAverage then

--- a/test.lua
+++ b/test.lua
@@ -32,6 +32,7 @@ function torch.Tester:assert_sub (condition, message)
    end
 end
 
+include 'testClassNLLCriterion.lua'
 include 'testLookupTable.lua'
 include 'testSpatialAveragePooling.lua'
 include 'testLogSoftMax.lua'
@@ -739,37 +740,6 @@ function clnntest.Sum_backward()
    local error = rescl:float() - groundgrad
    
    mytester:assertlt(error:abs():max(), precision_backward, 'error on state (backward) ')
-end
-
-function clnntest.ClassNLLCriterionMultipleTarget()
-   local size = 3000
-   local input = torch.randn(size, size)
-   local target = torch.randperm(size)
-   local mod = nn.ClassNLLCriterion()
-   
-   local tm = {}
-   local title = string.format('ClassNLLCriterionMultiTarget %d ',size)
-   times[title] = tm
-   
-   local a = torch.Timer()
-   local fout = mod:forward(input, target)
-   local fgin = mod:backward(input, target):clone()
-   tm.cpu = a:time().real
-   
-   local cinput = input:cl()
-   local ctarget = target:cl()
-   local cmod = nn.ClassNLLCriterion():cl()
-   a:reset()
-   local cout = cmod:forward(cinput,ctarget)
-   local cgin = cmod:backward(cinput,ctarget)
-   cltorch.synchronize()
-   tm.gpu = a:time().real
-   
-   mytester:assertlt(
-      math.abs(fout-cout), precision_forward, 'error on output')
-   
-   local gerr = cgin:float() - fgin
-   mytester:assertlt(gerr:abs():max(), precision_forward * 3, 'error on gradInput')
 end
 
 function clnntest.CMul_forward_batch()
@@ -2204,36 +2174,6 @@ function x_clnntest.l1cost()
    mytester:assertlt(gerr:abs():max(), precision_forward, 'error on gradInput')
 end
 
-
-function x_clnntest.ClassNLLCriterionSingleTarget()
-   local size = math.random(3000,5000)
-   local input = torch.randn(size)
-   local target = 1
-   local mod = nn.ClassNLLCriterion()
-   
-   local tm = {}
-   local title = string.format('ClassNLLCriterionSingleTarget %d ',size)
-   times[title] = tm
-   
-   local a = torch.Timer()
-   local fout = mod:forward(input, target)
-   local fgin = mod:backward(input, target):clone()
-   tm.cpu = a:time().real
-   
-   local cinput = input:cl()
-   local ctarget = torch.ClTensor(1):fill(target)
-   local cmod = nn.ClassNLLCriterion():cl()
-   a:reset()
-   local cout = cmod:forward(cinput,ctarget)
-   local cgin = cmod:backward(cinput,ctarget)
-   cltorch.synchronize()
-   tm.gpu = a:time().real
-   
-   mytester:assertlt(
-      math.abs(fout-cout), precision_forward, 'error on output')
-   local gerr = cgin:float() - fgin
-   mytester:assertlt(gerr:abs():max(), precision_forward, 'error on gradInput')
-end
 
 function x_clnntest.TemporalMaxPooling()
    local input = torch.rand(16, 18, 3)

--- a/test/testClassNLLCriterion.lua
+++ b/test/testClassNLLCriterion.lua
@@ -1,0 +1,69 @@
+local _test = clnn._test
+local times = _test.times
+local clnntest = _test.clnntest
+local x_clnntest = _test.x_clnntest
+local nloop = _test.nloop
+local precision_forward = 0.01
+local precision_backward = 0.01
+
+function clnntest.ClassNLLCriterionMultipleTarget()
+   local size = 3000
+   local input = torch.randn(size, size)
+   local target = torch.randperm(size)
+   local mod = nn.ClassNLLCriterion()
+   
+   local tm = {}
+   local title = string.format('ClassNLLCriterionMultiTarget %d ',size)
+   times[title] = tm
+   
+   local a = torch.Timer()
+   local fout = mod:forward(input, target)
+   local fgin = mod:backward(input, target):clone()
+   tm.cpu = a:time().real
+   
+   local cinput = input:cl()
+   local ctarget = target:cl()
+   local cmod = nn.ClassNLLCriterion():cl()
+   a:reset()
+   local cout = cmod:forward(cinput,ctarget)
+   local cgin = cmod:backward(cinput,ctarget)
+   cltorch.synchronize()
+   tm.gpu = a:time().real
+   
+   mytester:assertlt(
+      math.abs(fout-cout), precision_forward, 'error on output')
+   
+   local gerr = cgin:float() - fgin
+   mytester:assertlt(gerr:abs():max(), precision_forward * 3, 'error on gradInput')
+end
+
+function clnntest.ClassNLLCriterionSingleTarget()
+   local size = math.random(3000,5000)
+   local input = torch.randn(size)
+   local target = 1
+   local mod = nn.ClassNLLCriterion()
+   
+   local tm = {}
+   local title = string.format('ClassNLLCriterionSingleTarget %d ',size)
+   times[title] = tm
+   
+   local a = torch.Timer()
+   local fout = mod:forward(input, target)
+   local fgin = mod:backward(input, target):clone()
+   tm.cpu = a:time().real
+   
+   local cinput = input:cl()
+   local ctarget = torch.ClTensor(1):fill(target)
+   local cmod = nn.ClassNLLCriterion():cl()
+   a:reset()
+   local cout = cmod:forward(cinput,ctarget)
+   local cgin = cmod:backward(cinput,ctarget)
+   cltorch.synchronize()
+   tm.gpu = a:time().real
+   
+   mytester:assertlt(
+      math.abs(fout-cout), precision_forward, 'error on output')
+   local gerr = cgin:float() - fgin
+   mytester:assertlt(gerr:abs():max(), precision_forward, 'error on gradInput')
+end
+


### PR DESCRIPTION
Hi,

I was following up the 60 mins Torch tutorial at:

https://github.com/soumith/cvpr2015/blob/master/Deep%20Learning%20with%20Torch.ipynb

and wanted to modify it to run with OpenCL instead of CUDA. The tutorial relies on the basic StochasticGradient module provided by nn package, which does not accept 2D minibatch input. So the clnn ClassNLLCriterion module refused to run with the error 'Input to clnn.ClassNLLCriterion should be 2-d tensor'. I *really* wanted to finish this tutorial using OpenCL, and ended up modifying the code. I believe it covers one dimensional case completely.

Please review the code and save people like me!

Best regards,
Gloine